### PR TITLE
RTC-39142 Update public code example to use new service bus connection string format

### DIFF
--- a/ExportSubscriber/Azure/ServiceBus/ExportSubscriptionClient.cs
+++ b/ExportSubscriber/Azure/ServiceBus/ExportSubscriptionClient.cs
@@ -48,7 +48,7 @@ namespace ExportSubscriber.Azure.ServiceBus
             {
                 throw new ArgumentException("Invalid connection string");
             }
-            return parts[3];
+            return "/" + parts[3];
         }
 
         public ExportSubscriptionClient(ServiceBusClient client, string topicName, string subscriptionName)

--- a/ExportSubscriber/Azure/ServiceBus/ExportSubscriptionClient.cs
+++ b/ExportSubscriber/Azure/ServiceBus/ExportSubscriptionClient.cs
@@ -30,9 +30,25 @@ namespace ExportSubscriber.Azure.ServiceBus
                   new ServiceBusClient(
                       sbConnectionString, 
                       new ServiceBusClientOptions { Identifier = sbSubscriptionName }), 
-                  ServiceBusConnectionStringProperties.Parse(sbConnectionString).EntityPath, 
+                  parseTipicName(sbConnectionString), 
                   sbSubscriptionName)
         {
+        }
+
+        private static string parseTipicName(string sbConnectionString)
+        {
+            string entityPath = ServiceBusConnectionStringProperties.Parse(sbConnectionString).EntityPath;
+            if(entityPath != null)
+            {
+                return entityPath;
+            }
+
+            string[] parts = sbConnectionString.Split('/');
+            if(parts.Length < 4)
+            {
+                throw new ArgumentException("Invalid connection string");
+            }
+            return parts[3];
         }
 
         public ExportSubscriptionClient(ServiceBusClient client, string topicName, string subscriptionName)

--- a/ExportSubscriber/Config.cs
+++ b/ExportSubscriber/Config.cs
@@ -11,6 +11,7 @@ namespace ExportSubscriber
         public string ClientId { get; set; }
         public string OutputDirectory { get; set; }
         public string IntegrationPartnerName { get; private set; }
+        public string UseNewSBConnectionStringFormat  {get; set;}
 
         public static Config Read(IConfigurationRoot build)
         {
@@ -23,6 +24,7 @@ namespace ExportSubscriber
                 ClientId = build["ClientId"],
                 IntegrationPartnerName = build["IntegrationPartnerName"],
                 OutputDirectory = build["OutputDirectory"],
+                UseNewSBConnectionStringFormat = build["UseNewSBConnectionStringFormat"]
             };
         }
     }

--- a/ExportSubscriber/ExportSubscriber.csproj
+++ b/ExportSubscriber/ExportSubscriber.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.5" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
   </ItemGroup>

--- a/ExportSubscriber/Program.cs
+++ b/ExportSubscriber/Program.cs
@@ -17,7 +17,7 @@ namespace ExportSubscriber
             await job.Start();
 
             Console.WriteLine("Press any key to exit");
-            await Task.Run(() => { Console.ReadKey(); });
+            await Task.Run(() => { Console.Read(); });
         }
     }
 }

--- a/ExportSubscriber/Security/TenantService.cs
+++ b/ExportSubscriber/Security/TenantService.cs
@@ -23,6 +23,7 @@ namespace ExportSubscriber.Security
         private readonly string _resourceId;
         private readonly string _authorityUrl;
         private readonly string _clientId;
+        private readonly string _useNewSBConnectionStringFormat;
         private IConfidentialClientApplication _authContext;
 
         public TenantService(Config config)
@@ -35,6 +36,7 @@ namespace ExportSubscriber.Security
             _resourceId = config.TenantServiceResourceId;
             _authorityUrl = config.AuthorityUrl;
             _clientId = config.ClientId;
+            _useNewSBConnectionStringFormat = config.UseNewSBConnectionStringFormat == null ? "true" : config.UseNewSBConnectionStringFormat;
         }
 
         public async Task<ConnectionSecrets> GetSecrets()
@@ -56,7 +58,7 @@ namespace ExportSubscriber.Security
             Console.WriteLine($"Acquiring temporary connection secrets from {_tenantServiceUrl.Host}...");
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", authResult.AccessToken);
-            var postData = JsonSerializer.Serialize(new { integrationName = _integrationName });
+            var postData = JsonSerializer.Serialize(new { integrationName = _integrationName, useNewSBConnectionStringFormat = _useNewSBConnectionStringFormat });
             using var stringContent = new StringContent(postData, Encoding.UTF8, "application/json");
             using var result = await httpClient.PostAsync(_tenantServiceUrl, stringContent);
             result.EnsureSuccessStatusCode(); // If this gives you 403, you have not been granted the proper permissions yet.


### PR DESCRIPTION
1. use useNewSBConnectionStringFormat to get from tenant new sbConnectionString. Parse new sbConnectionString to get topic name. 
2. update version PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" 